### PR TITLE
Estimation of delay between trigger and analogue representation of stimulus

### DIFF
--- a/delayEstimation/extract_delays_MEG.py
+++ b/delayEstimation/extract_delays_MEG.py
@@ -1,0 +1,89 @@
+from mne import find_events, pick_channels, pick_events, Epochs
+from mne.io import Raw
+
+import re
+import numpy as np
+from os.path import join as opj
+from stormdb.access import Query
+import matplotlib.pyplot as plt
+plt.ion()
+
+
+def _next_crossing(a, triglim):
+    for a_ind, val in enumerate(a):
+        if (val - triglim[0]) > triglim[1]:
+            return a_ind
+
+    raise RuntimeError('ERROR: No analogue trigger found within %d samples '
+                       'of the digital trigger' % a_ind)
+
+
+def find_next_analogue_trigger(ana_data, ind, lim, maxdelay_samps=100):
+    return _next_crossing(ana_data[ind:ind + maxdelay_samps].squeeze(), lim)
+
+
+def _find_analogue_trigger_limit(ana_data):
+    return 2.5*ana_data.mean()
+
+
+def _find_analogue_trigger_limit_sd(raw, events, anapick, tmin=-0.2, tmax=0.2):
+    epochs = Epochs(raw, events, tmin=tmin, tmax=tmax, picks=anapick,
+                    baseline=(None, 0), preload=True)
+    epochs._data = np.sqrt(epochs._data**2)  # RECTIFY!
+    ave = epochs.average(picks=[0])
+    sde = epochs.standard_error(picks=[0])
+    return(ave.data.mean(),
+           5.0 * sde.data[0, np.where(sde.times < 0)].mean() *
+           np.sqrt(epochs.events.shape[0]))
+
+
+proj_name = 'MEG_service'
+subj_id = '0032'
+qy = Query(proj_name)
+
+series = qy.filter_series(description='audvis*', subj_ids=subj_id)
+
+stimchan = 'STI101'
+ana_chan = dict(vis='MISC001', aud='MISC008')
+trig_chan = dict(aud=7, vis=2)
+# Mixed up the triggers in the last session (PsyPy, separate presentations)
+trig_chans = [trig_chan, trig_chan, dict(aud=2, vis=7)]
+
+events = []
+raws = []
+for ser, trig_chan in zip(series, trig_chans):
+    m = re.search('00\d\.(.+?)/files', ser['path'])
+    condition_name = m.group(1)
+
+    raw_fname = opj(ser['path'], ser['files'][0])
+    raw = Raw(raw_fname, preload=True)
+    fig, axs = plt.subplots(1, 2)
+    for nax, modal in enumerate(['vis', 'aud']):
+        events = pick_events(find_events(raw, stim_channel=stimchan,
+                                         min_duration=0.002),
+                             include=trig_chan[modal])
+        delays = np.zeros(events.shape[0])
+        pick = pick_channels(raw.info['ch_names'], include=[ana_chan[modal]])
+
+        ana_data = np.sqrt(raw._data[pick, :].squeeze()**2)  # rectify!
+        triglo, trighi = _find_analogue_trigger_limit_sd(raw, events, pick)
+
+        print('Analogue data trigger limits: %.2g -> %.2g '
+              '(rectified)' % (triglo, trighi))
+        triglimits = (triglo, trighi)
+
+        for row, unpack_me in enumerate(events):
+            ind, before, after = unpack_me
+            raw_ind = ind - raw.first_samp  # really indices into raw!
+            anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
+                                                     triglimits,
+                                                     maxdelay_samps=1000)
+            delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
+
+        curtit = condition_name + ' : ' + modal
+        axs[nax].hist(delays)
+        axs[nax].set_title(curtit)
+
+        imgfig, _ = plt.subplots(1, 2)
+        mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
+        mnefig[0].get_axes()[0].set_title(curtit)

--- a/delayEstimation/extract_delays_MEG.py
+++ b/delayEstimation/extract_delays_MEG.py
@@ -1,12 +1,9 @@
 from mne import find_events, pick_channels, pick_events, Epochs
 from mne.io import Raw
 
-import re
 import numpy as np
 from os.path import join as opj
 from stormdb.access import Query
-import matplotlib.pyplot as plt
-plt.ion()
 
 
 def _next_crossing(a, offlevel, onlimit):
@@ -20,8 +17,8 @@ def _next_crossing(a, offlevel, onlimit):
         return(trig)
 
 
-def find_next_analogue_trigger(ana_data, ind, offlevel, onlimit,
-                               maxdelay_samps=100):
+def _find_next_analogue_trigger(ana_data, ind, offlevel, onlimit,
+                                maxdelay_samps=100):
     return _next_crossing(ana_data[ind:ind + maxdelay_samps].squeeze(),
                           offlevel, onlimit)
 
@@ -44,11 +41,6 @@ def _find_analogue_trigger_limit_sd(raw, events, anapick, tmin=-0.2, tmax=0.2):
 def extract_delays(series, stim_chan='STI101', misc_chan='MISC001',
                    trig_codes=None, plot_figures=True):
 
-    # NB HACK for hathor
-    m = re.search('00\d\.(.+?)/files', series['path'])
-    series['path'] = '/Users/cjb/data/MEG_service/audvis_latency_June2016/' +\
-                     m.group(0)
-
     raw_fname = opj(series['path'], series['files'][0])
     raw = Raw(raw_fname, preload=True)
 
@@ -69,12 +61,14 @@ def extract_delays(series, stim_chan='STI101', misc_chan='MISC001',
     for row, unpack_me in enumerate(events):
         ind, before, after = unpack_me
         raw_ind = ind - raw.first_samp  # really indices into raw!
-        anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
-                                                 offlevel, onlimit,
-                                                 maxdelay_samps=1000)
+        anatrig_ind = _find_next_analogue_trigger(ana_data, raw_ind,
+                                                  offlevel, onlimit,
+                                                  maxdelay_samps=1000)
         delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
 
     if plot_figures:
+        import matplotlib.pyplot as plt
+        plt.ion()
         curtit = 'foo'  # condition_name
         fig, axs = plt.subplots(1, 1)
 
@@ -87,57 +81,14 @@ def extract_delays(series, stim_chan='STI101', misc_chan='MISC001',
 
     return(delays)
 
-proj_name = 'MEG_service'
-subj_id = '0032'
-qy = Query(proj_name)
+if __name__ == '__main__':
+    proj_name = 'MEG_service'
+    subj_id = '0032'
+    qy = Query(proj_name)
 
-series = qy.filter_series('audvis*', subjects=subj_id)
+    series = qy.filter_series('audvis*', subjects=subj_id)
+    cur_series = series[0]
 
-stimchan = 'STI101'
-ana_chan = dict(vis='MISC001', aud='MISC008')
-trig_chan = dict(aud=7, vis=2)
-# Mixed up the triggers in the last session (PsyPy, separate presentations)
-trig_chans = [trig_chan, trig_chan, dict(aud=2, vis=7)]
-
-delays = extract_delays(series[0], stim_chan='STI101', misc_chan='MISC001',
-                        trig_codes=[2], plot_figures=True)
-
-# events = []
-# raws = []
-# for ser, trig_chan in zip(series, trig_chans):
-#     m = re.search('00\d\.(.+?)/files', ser['path'])
-#     condition_name = m.group(1)
-#
-#     ser['path'] = '/Users/cjb/data/MEG_service/audvis_latency_June2016/' +\
-#                   m.group(0)  # NB HACK FOR hathor
-#     raw_fname = opj(ser['path'], ser['files'][0])
-#     raw = Raw(raw_fname, preload=True)
-#     fig, axs = plt.subplots(1, 2)
-#     for nax, modal in enumerate(['vis', 'aud']):
-#         events = pick_events(find_events(raw, stim_channel=stimchan,
-#                                          min_duration=0.002),
-#                              include=trig_chan[modal])
-#         delays = np.zeros(events.shape[0])
-#         pick = pick_channels(raw.info['ch_names'], include=[ana_chan[modal]])
-#
-#         ana_data = np.sqrt(raw._data[pick, :].squeeze()**2)  # rectify!
-#         offlevel, onlimit = _find_analogue_trigger_limit_sd(raw, events, pick)
-#
-#         print('Analogue data trigger limits: %.2g -> %.2g '
-#               '(rectified)' % (offlevel, onlimit))
-#
-#         for row, unpack_me in enumerate(events):
-#             ind, before, after = unpack_me
-#             raw_ind = ind - raw.first_samp  # really indices into raw!
-#             anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
-#                                                      offlevel, onlimit,
-#                                                      maxdelay_samps=1000)
-#             delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
-#
-#         curtit = condition_name + ' : ' + modal
-#         axs[nax].hist(delays)
-#         axs[nax].set_title(curtit)
-#
-#         imgfig, _ = plt.subplots(1, 2)
-#         mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
-#         mnefig[0].get_axes()[0].set_title(curtit)
+    delays = extract_delays(cur_series, stim_chan='STI101',
+                            misc_chan='MISC001', trig_codes=[2],
+                            plot_figures=True)

--- a/delayEstimation/extract_delays_MEG.py
+++ b/delayEstimation/extract_delays_MEG.py
@@ -9,17 +9,21 @@ import matplotlib.pyplot as plt
 plt.ion()
 
 
-def _next_crossing(a, triglim):
-    for a_ind, val in enumerate(a):
-        if (val - triglim[0]) > triglim[1]:
-            return a_ind
+def _next_crossing(a, offlevel, onlimit):
+    try:
+        trig = np.where(np.abs(a - offlevel) >=
+                        np.abs(onlimit - offlevel))[0][0]
+    except IndexError:
+        raise RuntimeError('ERROR: No analogue trigger found within %d '
+                           'samples of the digital trigger' % len(a))
+    else:
+        return(trig)
 
-    raise RuntimeError('ERROR: No analogue trigger found within %d samples '
-                       'of the digital trigger' % a_ind)
 
-
-def find_next_analogue_trigger(ana_data, ind, lim, maxdelay_samps=100):
-    return _next_crossing(ana_data[ind:ind + maxdelay_samps].squeeze(), lim)
+def find_next_analogue_trigger(ana_data, ind, offlevel, onlimit,
+                               maxdelay_samps=100):
+    return _next_crossing(ana_data[ind:ind + maxdelay_samps].squeeze(),
+                          offlevel, onlimit)
 
 
 def _find_analogue_trigger_limit(ana_data):
@@ -37,11 +41,57 @@ def _find_analogue_trigger_limit_sd(raw, events, anapick, tmin=-0.2, tmax=0.2):
            np.sqrt(epochs.events.shape[0]))
 
 
+def extract_delays(series, stim_chan='STI101', misc_chan='MISC001',
+                   trig_codes=None, plot_figures=True):
+
+    # NB HACK for hathor
+    m = re.search('00\d\.(.+?)/files', series['path'])
+    series['path'] = '/Users/cjb/data/MEG_service/audvis_latency_June2016/' +\
+                     m.group(0)
+
+    raw_fname = opj(series['path'], series['files'][0])
+    raw = Raw(raw_fname, preload=True)
+
+    if trig_codes is not None:
+        include_trigs = trig_codes  # do some checking here!
+    events = pick_events(find_events(raw, stim_channel=stim_chan,
+                                     min_duration=0.002),
+                         include=include_trigs)
+    delays = np.zeros(events.shape[0])
+    pick = pick_channels(raw.info['ch_names'], include=[misc_chan])
+
+    ana_data = np.sqrt(raw._data[pick, :].squeeze()**2)  # rectify!
+    offlevel, onlimit = _find_analogue_trigger_limit_sd(raw, events, pick)
+
+    print('Analogue data trigger limits: %.2g -> %.2g '
+          '(rectified)' % (offlevel, onlimit))
+
+    for row, unpack_me in enumerate(events):
+        ind, before, after = unpack_me
+        raw_ind = ind - raw.first_samp  # really indices into raw!
+        anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
+                                                 offlevel, onlimit,
+                                                 maxdelay_samps=1000)
+        delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
+
+    if plot_figures:
+        curtit = 'foo'  # condition_name
+        fig, axs = plt.subplots(1, 1)
+
+        axs.hist(delays)
+        axs.set_title(curtit)
+
+        imgfig, _ = plt.subplots(1, 2)
+        mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
+        mnefig[0].get_axes()[0].set_title(curtit)
+
+    return(delays)
+
 proj_name = 'MEG_service'
 subj_id = '0032'
 qy = Query(proj_name)
 
-series = qy.filter_series(description='audvis*', subj_ids=subj_id)
+series = qy.filter_series('audvis*', subjects=subj_id)
 
 stimchan = 'STI101'
 ana_chan = dict(vis='MISC001', aud='MISC008')
@@ -49,41 +99,45 @@ trig_chan = dict(aud=7, vis=2)
 # Mixed up the triggers in the last session (PsyPy, separate presentations)
 trig_chans = [trig_chan, trig_chan, dict(aud=2, vis=7)]
 
-events = []
-raws = []
-for ser, trig_chan in zip(series, trig_chans):
-    m = re.search('00\d\.(.+?)/files', ser['path'])
-    condition_name = m.group(1)
+delays = extract_delays(series[0], stim_chan='STI101', misc_chan='MISC001',
+                        trig_codes=[2], plot_figures=True)
 
-    raw_fname = opj(ser['path'], ser['files'][0])
-    raw = Raw(raw_fname, preload=True)
-    fig, axs = plt.subplots(1, 2)
-    for nax, modal in enumerate(['vis', 'aud']):
-        events = pick_events(find_events(raw, stim_channel=stimchan,
-                                         min_duration=0.002),
-                             include=trig_chan[modal])
-        delays = np.zeros(events.shape[0])
-        pick = pick_channels(raw.info['ch_names'], include=[ana_chan[modal]])
-
-        ana_data = np.sqrt(raw._data[pick, :].squeeze()**2)  # rectify!
-        triglo, trighi = _find_analogue_trigger_limit_sd(raw, events, pick)
-
-        print('Analogue data trigger limits: %.2g -> %.2g '
-              '(rectified)' % (triglo, trighi))
-        triglimits = (triglo, trighi)
-
-        for row, unpack_me in enumerate(events):
-            ind, before, after = unpack_me
-            raw_ind = ind - raw.first_samp  # really indices into raw!
-            anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
-                                                     triglimits,
-                                                     maxdelay_samps=1000)
-            delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
-
-        curtit = condition_name + ' : ' + modal
-        axs[nax].hist(delays)
-        axs[nax].set_title(curtit)
-
-        imgfig, _ = plt.subplots(1, 2)
-        mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
-        mnefig[0].get_axes()[0].set_title(curtit)
+# events = []
+# raws = []
+# for ser, trig_chan in zip(series, trig_chans):
+#     m = re.search('00\d\.(.+?)/files', ser['path'])
+#     condition_name = m.group(1)
+#
+#     ser['path'] = '/Users/cjb/data/MEG_service/audvis_latency_June2016/' +\
+#                   m.group(0)  # NB HACK FOR hathor
+#     raw_fname = opj(ser['path'], ser['files'][0])
+#     raw = Raw(raw_fname, preload=True)
+#     fig, axs = plt.subplots(1, 2)
+#     for nax, modal in enumerate(['vis', 'aud']):
+#         events = pick_events(find_events(raw, stim_channel=stimchan,
+#                                          min_duration=0.002),
+#                              include=trig_chan[modal])
+#         delays = np.zeros(events.shape[0])
+#         pick = pick_channels(raw.info['ch_names'], include=[ana_chan[modal]])
+#
+#         ana_data = np.sqrt(raw._data[pick, :].squeeze()**2)  # rectify!
+#         offlevel, onlimit = _find_analogue_trigger_limit_sd(raw, events, pick)
+#
+#         print('Analogue data trigger limits: %.2g -> %.2g '
+#               '(rectified)' % (offlevel, onlimit))
+#
+#         for row, unpack_me in enumerate(events):
+#             ind, before, after = unpack_me
+#             raw_ind = ind - raw.first_samp  # really indices into raw!
+#             anatrig_ind = find_next_analogue_trigger(ana_data, raw_ind,
+#                                                      offlevel, onlimit,
+#                                                      maxdelay_samps=1000)
+#             delays[row] = anatrig_ind / raw.info['sfreq'] * 1.e3
+#
+#         curtit = condition_name + ' : ' + modal
+#         axs[nax].hist(delays)
+#         axs[nax].set_title(curtit)
+#
+#         imgfig, _ = plt.subplots(1, 2)
+#         mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
+#         mnefig[0].get_axes()[0].set_title(curtit)

--- a/delayEstimation/extract_delays_MEG.py
+++ b/delayEstimation/extract_delays_MEG.py
@@ -69,17 +69,22 @@ def extract_delays(series, stim_chan='STI101', misc_chan='MISC001',
     if plot_figures:
         import matplotlib.pyplot as plt
         plt.ion()
-        curtit = 'foo'  # condition_name
         fig, axs = plt.subplots(1, 1)
 
         axs.hist(delays)
-        axs.set_title(curtit)
+        axs.set_title('Delay histogram (ms)')
 
         imgfig, _ = plt.subplots(1, 2)
-        mnefig = Epochs(raw, events).plot_image(pick, fig=imgfig)
-        mnefig[0].get_axes()[0].set_title(curtit)
+        Epochs(raw, events).plot_image(pick, fig=imgfig)
+        # mnefig[0].get_axes()[1].set_title('')
 
-    return(delays)
+    stats = dict(mean=None, median=None, q10=None, q90=None)
+    stats['mean'] = np.mean(delays)
+    stats['std'] = np.std(delays)
+    stats['median'] = np.median(delays)
+    stats['q10'] = np.percentile(delays, 10.)
+    stats['q90'] = np.percentile(delays, 90.)
+    return(delays, stats)
 
 if __name__ == '__main__':
     proj_name = 'MEG_service'


### PR DESCRIPTION
We are interested in the delay between the TTL (parallel port) trigger signal indicating (usually) the onset of a stimulus, and the time at which the stimulus was actually presented. If we can feed an analogue representation of the stimulus (_e.g._, audio waveform or the output of an optodiode on the projection screen) to a MISC channel on the MEG, we can record the delay. This PR is a script/function for extracting some statistics on the trigger-to-stimulus delay (especially for making sure there is no _jitter_).
